### PR TITLE
Remove rad/s, fix misuse of Kinematics, Closes #45

### DIFF
--- a/test_motors/src/firmware.cpp
+++ b/test_motors/src/firmware.cpp
@@ -92,16 +92,6 @@ PID motor2_pid(PWM_MIN, PWM_MAX, K_P, K_I, K_D);
 PID motor3_pid(PWM_MIN, PWM_MAX, K_P, K_I, K_D);
 PID motor4_pid(PWM_MIN, PWM_MAX, K_P, K_I, K_D);
 
-Kinematics kinematics(
-    Kinematics::LINO_BASE,
-    MOTOR_MAX_RPM,
-    MAX_RPM_RATIO,
-    MOTOR_OPERATING_VOLTAGE,
-    MOTOR_POWER_MAX_VOLTAGE,
-    WHEEL_DIAMETER,
-    LR_WHEELS_DISTANCE
-);
-
 Odometry odometry;
 IMU imu;
 MAG mag;
@@ -173,12 +163,12 @@ void loop() {
     if (current_motor == 3 && tk % run_time == run_time - 1) max_rpm = current_rpm4;
     if (total_motors == 4 && current_motor == 0 && tk % run_time == 0) stopping = current_rpm4;
     if (tk && tk % run_time == 0) {
-        Kinematics::velocities max_linear = kinematics.getVelocities(max_rpm, max_rpm, max_rpm, max_rpm);
-	Kinematics::velocities max_angular = kinematics.getVelocities(-max_rpm, max_rpm,-max_rpm, max_rpm);
-	Serial.printf("MOTOR%d SPEED %6.2f m/s %6.2f rad/s STOP %6.3f m\n", current_motor ? current_motor : total_motors,
-	       max_linear.linear_x, max_angular.angular_z, max_linear.linear_x * stopping / max_rpm);
-	syslog(LOG_INFO, "MOTOR%d SPEED %6.2f m/s %6.2f rad/s STOP %6.3f m\n", current_motor ? current_motor : total_motors,
-	       max_linear.linear_x, max_angular.angular_z, max_linear.linear_x * stopping / max_rpm);
+        float max_linear_speed = max_rpm / 60.0 * PI * WHEEL_DIAMETER; // m/s = rps * circumference
+
+        Serial.printf("MOTOR%d SPEED %6.2f m/s STOP %6.3f m\n", current_motor ? current_motor : total_motors,
+	       max_linear_speed, max_linear_speed * stopping / max_rpm);
+        syslog(LOG_INFO, "MOTOR%d SPEED %6.2f m/s STOP %6.3f m\n", current_motor ? current_motor : total_motors,
+	       max_linear_speed, max_linear_speed * stopping / max_rpm);
     }
     Serial.printf("MOTOR%d %s RPM %8.1f %8.1f %8.1f %8.1f\n",
 	   current_motor + 1, direction ? "REV" : "FWD",


### PR DESCRIPTION
I was running test_motors on my differential drive robot and noticed it prints a rad/sec value which is two times what my hand-calculation says it should be based on one wheel spinning and one wheel stopped.

MOTOR1 FWD RPM 158.4 0.0 0.0 0.0
MOTOR1 SPEED 0.66 m/s 8.14 rad/s STOP 0.087 m
The wheels are 80mm diameter and 163mm apart.

Looking at the code, it was misusing the Kinematics class, and shouldn't have been using that class at all.

The purpose of test_motors is to print the RPM and velocity of each wheel as it runs them in turn. Since only one motor runs at a time, and the focus is on the running motor, it is irrelevant what the platform would be doing, so the use of Kinematics (which is a platform-level class) is inappropriate.

Wheel speed was computed in Kinematics as
vel.linear_x = average_rps_x * wheel_circumference_; // m/s
and this is the calculation that I moved up into test_motors, so the instance of Kinematics is no longer needed. It only gave the right answer for the single running wheel because test_motors passed max_rpm in as if both the left and right motors were running, so the wheel speed average worked out (hack). It was incorrect if the platform was put on the ground and allowed to spin on the stationary wheel. IOW knowledge of how Kinematics is implemented was being used by test_motors, which worked but is poor practice. Removing the Kinematics instance fixed this.

Wheel rad/s doesn't seem like an interesting parameter, and in any case was calculated incorrectly. It was removed from the print. 

