### PR TITLE
change rclc_timer_init_default to rc_timer_init_default2

### DIFF
--- a/firmware/src/firmware.cpp
+++ b/firmware/src/firmware.cpp
@@ -442,11 +442,12 @@ bool createEntities()
 #endif
     // create timer for actuating the motors at 50 Hz (1000/20)
     const unsigned int control_timeout = CONTROL_TIMER;
-    RCCHECK(rclc_timer_init_default(
+    RCCHECK(rclc_timer_init_default2(
         &control_timer,
         &support,
         RCL_MS_TO_NS(control_timeout),
-        controlCallback
+        controlCallback,
+        true
     ));
     RCCHECK(rclc_executor_init(&executor, &support.context, 3, &allocator));
     RCCHECK(rclc_executor_add_subscription(


### PR DESCRIPTION
This PR fixes part of Issue #82. 

On issue 1, looking at https://github.com/ros2/rclc/blob/jazzy/rclc/src/rclc/timer.c, calling rclc_timer_init_default results in it turning around and calling rclc_timer_init_default2 with autostart true. Therefore it is safe to simply replace the deprecated call with the new one, passing true for autostart. 